### PR TITLE
Adds support for Azure OpenAI Service + question prefix

### DIFF
--- a/classes/story_form.php
+++ b/classes/story_form.php
@@ -59,6 +59,11 @@ class local_aiquestions_story_form extends moodleform {
         $mform->setType('story', PARAM_RAW);
         $mform->addHelpButton('story', 'story', 'local_aiquestions');
 
+        // Add "GPT-created" to question name.
+        $mform->addElement('checkbox', 'addidentifier', get_string('addidentifier', 'local_aiquestions'));
+        $mform->setDefault('addidentifier', 1); // Default of "yes"
+        $mform->setType('addidentifier', PARAM_BOOL);
+
         // Preset.
         $presets = array();
         for ($i = 0; $i < 10; $i++) {

--- a/classes/task/questions.php
+++ b/classes/task/questions.php
@@ -53,6 +53,7 @@ class questions extends \core\task\adhoc_task {
         $userid = $data->userid;
         $uniqid = $data->uniqid;
         $numofquestions = $data->numofquestions;
+        $addidentifier = $data->addidentifier;
 
         // Create the DB entry.
         $dbrecord = new \stdClass();
@@ -101,7 +102,7 @@ class questions extends \core\task\adhoc_task {
                 if (\local_aiquestions_check_gift($questions->text)) {
 
                     // Create the questions, return an array of objetcs of the created questions.
-                    $created = \local_aiquestions_create_questions($courseid, $category, $questions->text, $numofquestions, $userid);
+                    $created = \local_aiquestions_create_questions($courseid, $category, $questions->text, $numofquestions, $userid, $addidentifier);
                     $j = 0;
                     foreach ($created as $question) {
                         $success[$j]['id'] = $question->id;

--- a/lang/en/local_aiquestions.php
+++ b/lang/en/local_aiquestions.php
@@ -33,10 +33,14 @@ $string['privacy:metadata'] = 'AI text to questions generator does not store any
 $string['aiquestions'] = 'AI Questions';
 
 // Settings page.
-$string['openaikey'] = 'OpenAI API key';
-$string['openaikeydesc'] = 'You can get your API key from <a href="https://platform.openai.com/account/api-keys">https://platform.openai.com/account/api-keys</a><br>
+$string['provider'] = 'GPT provider';
+$string['providerdesc'] = 'Select if you are using Azure of OpenAI';
+$string['azureapiendpoint'] = 'Azure API Endpoint';
+$string['azureapiendpointdesc'] = 'Enter the Azure API endpoint URL here';
+$string['openaikey'] = 'OpenAI or Azure API key';
+$string['openaikeydesc'] = 'You can get an OpenAI API key from <a href="https://platform.openai.com/account/api-keys">https://platform.openai.com/account/api-keys</a><br>
 Select the "+ Create New Secret Key" button and copy the key to this field.<br>
-Note that you need to have an OpenAI account that include billing settings to get an API key.';
+Note that you need to have an OpenAI account that includes billing settings to get an API key.';
 $string['model'] = 'Model';
 $string['model_desc'] = 'Language model to use. <a href="https://platform.openai.com/docs/models/">More info</a>.';
 $string['presetname'] = 'Preset name';
@@ -55,6 +59,7 @@ $string['shareyourprompts'] = 'You can find more prompt ideas or share yours at 
 // Story form.
 $string['category'] = 'Question category';
 $string['category_help'] = 'If the category selection is empty, open the question bank for this course once.';
+$string['addidentifier'] = 'Add a "GPT-created: " prefix to the question name';
 $string['editpreset'] = 'Edit the preset before sending it to the AI';
 $string['primer'] = 'Primer';
 $string['primer_help'] = 'The primer is the first information to be sent to the AI, priming it for its task.';

--- a/settings.php
+++ b/settings.php
@@ -28,6 +28,28 @@ defined('MOODLE_INTERNAL') || die();
 if ($hassiteconfig) {
     $settings = new admin_settingpage('local_aiquestions_settings', new lang_string('pluginname', 'local_aiquestions'));
 
+    // Language model provider.
+    $provideroptions = ['OpenAI' => 'OpenAI',
+                'Azure' => 'Azure'
+                ];
+    $settings->add( new admin_setting_configselect(
+        'local_aiquestions/provider',
+        get_string('provider', 'local_aiquestions'),
+        get_string('providerdesc', 'local_aiquestions'),
+        'OpenAI',
+        $provideroptions,
+    ));
+
+    // Azure endpoint.
+
+    $settings->add(new admin_setting_configtext(
+    'local_aiquestions/azure_api_endpoint',
+    get_string('azureapiendpoint', 'local_aiquestions'),
+    get_string('azureapiendpointdesc', 'local_aiquestions'),
+    '', PARAM_URL
+    ));
+
+
     // OpenAI key.
     $settings->add( new admin_setting_configpasswordunmask(
         'local_aiquestions/key',

--- a/story.php
+++ b/story.php
@@ -74,6 +74,7 @@ if ($mform->is_cancelled()) {
                                 'example' => $data->$example,
                                 'story' => $data->story,
                                 'numofquestions' => $data->numofquestions,
+                                'addidentifier' => $data->addidentifier,
                                 'courseid' => $data->courseid,
                                 'userid' => $USER->id,
                                 'uniqid' => $uniqid ]);

--- a/tests/questions_test.php
+++ b/tests/questions_test.php
@@ -59,8 +59,8 @@ class questions_test extends \advanced_testcase {
         // Create user.
         $user = $this->getDataGenerator()->create_user();
         $course = $this->getDataGenerator()->create_course();
-        // Params are : courseid, gift, numofquestions, userid.
-        $question = \local_aiquestions_create_questions($course->id, $gift, 1, $user->id);
+        // Params are : courseid, gift, numofquestions, userid, addidentifier.
+        $question = \local_aiquestions_create_questions($course->id, $gift, 1, $user->id, 1);
         $this->assertEquals($question[0]->name, 'My interesting questionText');
         $this->assertEquals($question[0]->qtype, 'multichoice');
     }


### PR DESCRIPTION
As I wrote in issue #9, there is now an admin option to choose between API endpoints. 

Also, I added an optional "GPT-created:" prefix to question names. (Sorry that it is in the same commit!)